### PR TITLE
Remove SHARED from pybind11_add_module

### DIFF
--- a/netperf_tool/CMakeLists.txt
+++ b/netperf_tool/CMakeLists.txt
@@ -34,7 +34,7 @@ find_package(pybind11 REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME})
 
-pybind11_add_module(netperf_tool_impl SHARED
+pybind11_add_module(netperf_tool_impl
   src/client_node.cpp
   src/client_runner.cpp
   src/node_runner.cpp


### PR DESCRIPTION
See https://github.com/ros2/rclpy/pull/1305 and https://github.com/ros2/rclpy/pull/1418 for more context.

In a nutshell, passing `SHARED` to `pybind11_add_module` results in a segfault on macOS on Python with libpython statically linked, as the python package shipped by conda-forge.